### PR TITLE
Set overclock multiplier at boot.

### DIFF
--- a/mednafen/pce/pce.cpp
+++ b/mednafen/pce/pce.cpp
@@ -372,6 +372,8 @@ static MDFN_COLD int LoadCommon(void)
 
 	HuCPU.SetReadHandler(0xFF, IORead);
 	HuCPU.SetWriteHandler(0xFF, IOWrite);
+	
+	HuCPU.SetOverclock(MDFN_GetSettingUI("pce.ocmultiplier"));
 
 	int psgrevision = MDFN_GetSettingI("pce.psgrevision");
 


### PR DESCRIPTION
fixes https://github.com/libretro/beetle-pce-libretro/issues/29