### PR TITLE
Add core options to default to 2 or 6 buttons controllers + visibility cleanups

### DIFF
--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -295,6 +295,20 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "3"
    },
    {
+      "pce_show_advanced_input_settings",
+      "Show Advanced Input/Turbo Settings",
+      NULL,
+      "Show Multitap, Mouse, Turbo Buttons and advanced parameters. NOTE: You may need to go back in game and re-enter the menu to refresh the list.",
+      NULL,
+      NULL,
+      {
+         { "enabled",  NULL },
+         { "disabled", NULL },
+         { NULL, NULL},
+      },
+      "disabled"
+   },
+   {
       "pce_mouse_sensitivity",
       "Mouse Sensitivity",
       NULL,
@@ -374,18 +388,74 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "enabled"
    },
    {
-      "pce_show_advanced_input_settings",
-      "Show Advanced Input/Turbo Settings",
+      "pce_default_joypad_type_p1",
+      "P1 Default Joypad Type",
       NULL,
-      "Show Multitap, Mouse, Turbo Buttons and advanced parameters. NOTE: You need to go back in game and re-enter the menu to refresh the list.",
+      "Choose if port 1 joypad should be 2 or 6 buttons by default. This option is only applied when the core starts, if you want to switch while content is running, use the 'Mode Switch' button. NOTE: 6 buttons joypad can have weird behaviors in non compatible games.",
       NULL,
-      NULL,
+      "input",
       {
-         { "enabled",  NULL },
-         { "disabled", NULL },
+         { "2 Buttons", NULL },
+         { "6 Buttons", NULL },
          { NULL, NULL},
       },
-      "disabled"
+      "2 Buttons"
+   },
+   {
+      "pce_default_joypad_type_p2",
+      "P2 Default Joypad Type",
+      NULL,
+      "Choose if port 2 joypad should be 2 or 6 buttons by default. This option is only applied when the core starts, if you want to switch while content is running, use the 'Mode Switch' button. NOTE: 6 buttons joypad can have weird behaviors in non compatible games.",
+      NULL,
+      "input",
+      {
+         { "2 Buttons", NULL },
+         { "6 Buttons", NULL },
+         { NULL, NULL},
+      },
+      "2 Buttons"
+   },
+   {
+      "pce_default_joypad_type_p3",
+      "P3 Default Joypad Type",
+      NULL,
+      "Choose if port 3 joypad should be 2 or 6 buttons by default. This option is only applied when the core starts, if you want to switch while content is running, use the 'Mode Switch' button. NOTE: 6 buttons joypad can have weird behaviors in non compatible games.",
+      NULL,
+      "input",
+      {
+         { "2 Buttons", NULL },
+         { "6 Buttons", NULL },
+         { NULL, NULL},
+      },
+      "2 Buttons"
+   },
+   {
+      "pce_default_joypad_type_p4",
+      "P4 Default Joypad Type",
+      NULL,
+      "Choose if port 4 joypad should be 2 or 6 buttons by default. This option is only applied when the core starts, if you want to switch while content is running, use the 'Mode Switch' button. NOTE: 6 buttons joypad can have weird behaviors in non compatible games.",
+      NULL,
+      "input",
+      {
+         { "2 Buttons", NULL },
+         { "6 Buttons", NULL },
+         { NULL, NULL},
+      },
+      "2 Buttons"
+   },
+   {
+      "pce_default_joypad_type_p5",
+      "P5 Default Joypad Type",
+      NULL,
+      "Choose if port 5 joypad should be 2 or 6 buttons by default. This option is only applied when the core starts, if you want to switch while content is running, use the 'Mode Switch' button. NOTE: 6 buttons joypad can have weird behaviors in non compatible games.",
+      NULL,
+      "input",
+      {
+         { "2 Buttons", NULL },
+         { "6 Buttons", NULL },
+         { NULL, NULL},
+      },
+      "2 Buttons"
    },
    {
       "pce_Turbo_Toggling",


### PR DESCRIPTION
Add core options to let the user chose if the joypads should be 2 or 6 buttons by default, so if you want to play a 6 buttons game, you don't have to press the "Mode Switch" every time you boot it. It's also very useful for SNES-like controllers without a "L2" button, previously you had to remap the "Mode Switch" button, return to game and press it, then remap it back, super annoying...

Made a few changes to the "Show Advanced Input/Turbo Settings" option as well:

* Moved it so it's on top of the input options if categories are not supported/disabled, it was previously in the middle of them which felt unintuitive.
* It was glitchy, even if the option was OFF the "Input" category was still appearing with all the options available inside, the category then disappeared as soon as you made any change in it. Now the category is always visible if categories are supported/enabled.
* If categories are not supported/disabled, inputs options are now shown/hidden in real time, no need to toggle the quick menu (as long as `RETRO_ENVIRONMENT_SET_CORE_OPTIONS_UPDATE_DISPLAY_CALLBACK` is supported by the frontend, of course).