### PR TITLE
Fix various issues with 6-buttons/multitap

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -1091,9 +1091,9 @@ static void check_variables(bool loaded)
          snprintf(key, sizeof(key), "pce_default_joypad_type_p%d", i + 1);
          if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
          {
-            if(strcmp(var.value, "2 Buttons") == 0)
+            if (strcmp(var.value, "2 Buttons") == 0)
                avpad6_enable[i] = 0;
-            else if(strcmp(var.value, "6 Buttons") == 0)
+            else if (strcmp(var.value, "6 Buttons") == 0)
                avpad6_enable[i] ^= (1 << 12);
          }
       }

--- a/mednafen/pce/input/gamepad.cpp
+++ b/mednafen/pce/input/gamepad.cpp
@@ -98,8 +98,8 @@ void PCE_Input_Gamepad::Write(int32 timestamp, bool old_SEL, bool new_SEL, bool 
 	SEL = new_SEL;
 	CLR = new_CLR;
 
-	//if(old_SEL && new_SEL && old_CLR && !new_CLR)
-	if(!old_SEL && new_SEL)
+	//if(!old_SEL && new_SEL)
+	if(old_SEL && new_SEL && old_CLR && !new_CLR)
 		AVPad6Which = !AVPad6Which;
 }
 


### PR DESCRIPTION
As discussed here: https://github.com/libretro/RetroArch/issues/15251 this fixes some 6-buttons/multitap issues. From my tests it also fixes the games mentioned in #60.

Like I said in that other issue, idk if this can have side effects in other games, I tried additional random games and they worked fine. Could be reverted in worst case if we get some regression reports.