### PR TITLE
Prevent crash if BIOS is missing

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -1847,12 +1847,13 @@ void retro_get_system_av_info(struct retro_system_av_info *info)
 
 void retro_deinit()
 {
-   if (surf->pixels)
-      free(surf->pixels);
-   surf->pixels = NULL;
-
    if (surf)
+   {
+      if (surf->pixels)
+         free(surf->pixels);
+      surf->pixels = NULL;
       free(surf);
+   }
    surf = NULL;
 
    if (log_cb)

--- a/mednafen/pce/pce.cpp
+++ b/mednafen/pce/pce.cpp
@@ -449,7 +449,10 @@ MDFN_COLD int PCE_LoadCD(std::vector<CDIF *> *CDInterfaces)
 
 	MDFNFILE *fp = file_open(bios_path.c_str());
 	if (!fp)
+	{
+		MDFN_DispMessage("Firmware not found: '%s'", bios_path.c_str());
 		return 0;
+	}
 
 	bool disable_bram_cd = MDFN_GetSettingB("pce.disable_bram_cd");
 


### PR DESCRIPTION
**edit:** Added a message so the user knows why it fails to load.