### PR TITLE
Change Owl resampler default

### DIFF
--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -292,7 +292,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
          { "6", NULL },
          { NULL, NULL},
       },
-      "3"
+      "0"
    },
    {
       "pce_show_advanced_input_settings",


### PR DESCRIPTION
Set Owl resampler default to 0 (lowest quality) instead of 3.
Gives a 20~25% emulation speed boost, can't say I hear a difference when comparing 0 to 6.

Still keeping the "3 default" name to hint at mednafen default.

We can get more on top of that but I don't know how to code it/make it optional:
https://github.com/libretro/beetle-pce-libretro/issues/81