### PR TITLE
Fix Aero Blasters crash.

### DIFF
--- a/mednafen/pce/vce.cpp
+++ b/mednafen/pce/vce.cpp
@@ -36,7 +36,7 @@
 vce_resolution_t vce_resolution;
 
 static bool hires;
-static int scanline_start, scanline_end;
+static int scanline_start, scanline_end=242;
 
 static struct
 {


### PR DESCRIPTION
Fix Aero Blasters crash because of uninitialized value that leads to invalid scaling calculations.
Thanks to @negativeExponent for the fix.

This fixes https://github.com/libretro/beetle-pce-libretro/issues/52