### PR TITLE
vce.cpp: Fix buffer-overflow causing excessive calls to SET_GEOMETRY

### DIFF
--- a/mednafen/pce/vce.cpp
+++ b/mednafen/pce/vce.cpp
@@ -47,7 +47,7 @@ static struct
 
 	int rate;
 	int line;
-} scanline_info[10];
+} scanline_info[16];
 
 static int scanline_info_count;
 


### PR DESCRIPTION
Fix: https://github.com/libretro/beetle-pce-libretro/issues/78